### PR TITLE
Follow-up to #19 

### DIFF
--- a/R/plot.data_table_threads_benchmark.R
+++ b/R/plot.data_table_threads_benchmark.R
@@ -45,8 +45,8 @@ plot.data_table_threads_benchmark <- function(x, ...)
   )
   
   closestPoints <- x[, {
-    recommendedDataSubset <- recommendedSpeedupData[threadCount %in% .SD$threadCount]
-    .SD[which.max(speedup - recommendedDataSubset$speedup)]
+    recommendedSubset <- recommendedSpeedupData[threadCount %in% .SD$threadCount]
+    .SD[.SD$speedup > recommendedSubset$speedup][which.max(speedup)]
   }, by = expr]
   closestPoints[, type := "Recommended"]
   

--- a/R/plot.data_table_threads_benchmark.R
+++ b/R/plot.data_table_threads_benchmark.R
@@ -38,15 +38,15 @@ plot.data_table_threads_benchmark <- function(x, ...)
 
   maxSpeedup <- x[, .(threadCount = threadCount[which.max(speedup)], speedup = max(speedup), type = "Ideal"), by = expr]
 
-  subOptimalSpeedupData <- data.table(
+  recommendedSpeedupData <- data.table(
     threadCount = seq(1, systemThreadCount, length.out = systemThreadCount),
     speedup = seq(1, systemThreadCount / 2, length.out = systemThreadCount),
-    type = "Sub-optimal"
+    type = "Recommended"
   )
   
   closestPoints <- x[, {
-    suboptimalSubset <- subOptimalSpeedupData[threadCount %in% .SD$threadCount]
-    .SD[which.max(speedup - suboptimalSubset$speedup)]
+    recommendedDataSubset <- recommendedSpeedupData[threadCount %in% .SD$threadCount]
+    .SD[which.max(speedup - recommendedDataSubset$speedup)]
   }, by = expr]
   closestPoints[, type := "Recommended"]
   

--- a/R/plot.data_table_threads_benchmark.R
+++ b/R/plot.data_table_threads_benchmark.R
@@ -46,7 +46,7 @@ plot.data_table_threads_benchmark <- function(x, ...)
   
   closestPoints <- x[, {
     recommendedSubset <- recommendedSpeedupData[threadCount %in% .SD$threadCount]
-    .SD[.SD$speedup > recommendedSubset$speedup][which.max(speedup)]
+    .SD[.SD$speedup >= recommendedSubset$speedup][which.max(speedup)]
   }, by = expr]
   closestPoints[, type := "Recommended"]
   


### PR DESCRIPTION
Includes:
- Removal of the sub-optimal type (confused it with some old code, easy fix)
- Refactoring of the logic that computes `closestPoints`

I was skeptical about going with the second point at first since technically, it looks like it's working:

<img width="1723" alt="image" src="https://github.com/user-attachments/assets/70a0d724-e6f0-4976-9453-0b86c25cad29">

And I've also been finally getting results that extend beyond 2 for a 'Recommended' value (previously that was the max I got for some reason), for functions like `forder` for e.g.:

<img width="247" alt="image" src="https://github.com/user-attachments/assets/fcb7c107-ebc4-4ccb-9d82-f3360d507bb6">


But logically, I agree with Toby's comments and reasoning as maximizing the difference like I did would not yield accurate results/points always. 

AFAIU, for each function/`expr` I need to first filter the 'Measured' `speedup`/y-axis values that are greater (or it should be equal too as I think? `ge` should be the case imo) than the 'Recommended' speedup values (coming from the 0.5 slope line), find whichever value is the highest among them, and then collectively (with it's corresponding x-axis/`threadCount` value) assign it as the point of intersection.